### PR TITLE
Update build.sh to also match CrashPlan PRO 2010

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,7 @@ $CMD_CP -r $DIR_SRC_QPKG/* $DIR_QPKG
 
 # Extract Crashplan package
 $CMD_TAR xzf $1 -C $DIR_DATA
-CPIFILE_NAME=`$CMD_LS -1 $DIR_DATA/crashplan-install/*cpi`
+CPIFILE_NAME=`$CMD_LS -1 $DIR_DATA/[cC]rash[pP]lan*-install/*cpi`
 $CMD_MV $CPIFILE_NAME $DIR_DATA/CrashPlan.cpi
 cd $DIR_DATA && $CMD_CAT ./CrashPlan.cpi | gzip -dc - | cpio -i --no-preserve-owner && cd -
 
@@ -44,7 +44,7 @@ echo "JAVACOMMON=$PATH_TO_JAVA" > $DIR_DATA/crashplan.vars
 $CMD_GREP "SRV_JAVA_OPTS" $DIR_DATA/crashplan-install/scripts/run.conf >> $DIR_DATA/crashplan.vars
 
 # Clean data folder
-$CMD_RM -rf $DIR_DATA/crashplan-install
+$CMD_RM -rf $DIR_DATA/[cC]rash[pP]lan*-install
 $CMD_RM -f $DIR_DATA/CrashPlan.cpi
 $CMD_RM -rf $DIR_DATA/bin
 $CMD_RM -rf $DIR_DATA/upgrade


### PR DESCRIPTION
CrashPlan PRO 2010 extracts its files in a folder containing camel casing CrashPlan instead all lower case crashplan. The temporary extraction folder name also includes the word PRO. This change will catch both variants.