### PR TITLE
Add cpio dependency check to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Check dependency
+command -v cpio >/dev/null 2>&1 || { echo >&2 "I require cpio but it's not installed. Aborting. You might want to try 'opkg install cpio'."; exit 1; }
+
 CMD_RM="/bin/rm"
 CMD_TAR="/bin/tar"
 CMD_MKDIR="/bin/mkdir"


### PR DESCRIPTION
Build.sh uses cpio. On a factory cleaned QNAP with QDK, there is no cpio available. Check for this situation, and abort when cpio is not available.