### PR TITLE
build.sh: try to find java at more locations & abort when empty

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,7 +42,10 @@ $CMD_MV $CPIFILE_NAME $DIR_DATA/CrashPlan.cpi
 cd $DIR_DATA && $CMD_CAT ./CrashPlan.cpi | gzip -dc - | cpio -i --no-preserve-owner && cd -
 
 # Create crashplan.vars file
-PATH_TO_JAVA=`command -v java`
+PATH_TO_JAVA=$(command -v java)
+[ -z "$PATH_TO_JAVA" ] && [ -f /usr/local/jre/bin/java ] && PATH_TO_JAVA='/usr/local/jre/bin/java'
+[ -z "$PATH_TO_JAVA" ] && PATH_TO_JAVA=$(find -L /usr -name 'java' -print -quit)
+[ -z "$PATH_TO_JAVA" ] && { echo 'Path to java can not be found. Aborting.'; exit 1; }
 echo "JAVACOMMON=$PATH_TO_JAVA" > $DIR_DATA/crashplan.vars
 $CMD_GREP "SRV_JAVA_OPTS" $DIR_DATA/[cC]rash[pP]lan*-install/scripts/run.conf >> $DIR_DATA/crashplan.vars
 


### PR DESCRIPTION
CrashPlan will not start when java can't be located. Therefore stop build when PATH_TO_JAVA a.k.a. JAVACOMMON is empty.

Also adding some more fallback mechanisms to find java.